### PR TITLE
Add about section to landing page

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,19 +1,26 @@
 :root {
   color-scheme: dark;
-  --background: #0f0f12;
-  --surface: #1b1b21;
-  --surface-highlight: #20202a;
-  --text-primary: #ffffff;
-  --text-secondary: rgba(255, 255, 255, 0.65);
+  --bg-primary: #07070b;
+  --bg-elevated: #11121b;
+  --bg-soft: rgba(255, 255, 255, 0.04);
+  --bg-gradient: radial-gradient(circle at 10% 20%, #1c2140 0%, #0b0d15 45%, #06060a 100%);
+  --text-primary: #f5f7ff;
+  --text-secondary: rgba(245, 247, 255, 0.72);
   --accent: #f6b76f;
-  --accent-strong: #ffd29f;
-  --border-soft: rgba(255, 255, 255, 0.1);
-  --border-strong: rgba(255, 255, 255, 0.25);
-  --shadow-soft: 0 20px 40px rgba(0, 0, 0, 0.35);
-  --font-sans: "Manrope", "Inter", "Segoe UI", sans-serif;
+  --accent-strong: #ffd89b;
+  --outline: rgba(255, 255, 255, 0.12);
+  --outline-strong: rgba(255, 255, 255, 0.32);
+  --shadow: 0 24px 48px rgba(4, 7, 16, 0.45);
+  --radius-lg: 36px;
+  --radius-md: 22px;
+  --radius-sm: 14px;
+  --font-sans: "Manrope", "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  --transition: 0.25s ease;
 }
 
-* {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
 }
 
@@ -21,10 +28,19 @@ body {
   margin: 0;
   min-height: 100vh;
   font-family: var(--font-sans);
-  background: radial-gradient(circle at 15% 15%, #1d202f 0%, #0e0e13 45%, #09090b 100%);
+  background: var(--bg-gradient);
   color: var(--text-primary);
   display: flex;
   flex-direction: column;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: linear-gradient(160deg, rgba(246, 183, 111, 0.08), transparent 55%);
+  pointer-events: none;
+  z-index: -1;
 }
 
 a {
@@ -32,579 +48,942 @@ a {
   text-decoration: none;
 }
 
-header {
-  padding: 32px 64px;
+img {
+  max-width: 100%;
+  display: block;
+  border-radius: inherit;
 }
 
-.main-wrapper {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  padding: 0 64px 64px;
+p {
+  margin: 0;
+}
+
+.site-header {
+  padding: 32px 0 16px;
+}
+
+.container {
+  width: min(1200px, 100% - 64px);
+  margin: 0 auto;
 }
 
 .navbar {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  max-width: 1200px;
-  margin: 0 auto;
+  gap: 32px;
 }
 
 .brand {
   display: inline-flex;
   align-items: center;
   gap: 12px;
+  padding: 10px 18px;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.05);
+  letter-spacing: 0.12em;
   font-weight: 600;
-  font-size: 20px;
-  letter-spacing: 0.08em;
+  font-size: 18px;
   text-transform: uppercase;
+  position: relative;
+  overflow: hidden;
 }
 
 .brand::before {
   content: "";
-  width: 40px;
-  height: 40px;
-  border-radius: 14px;
-  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
-  box-shadow: 0 10px 20px rgba(246, 183, 111, 0.35);
+  position: absolute;
+  inset: -90% auto auto -10%;
+  width: 72px;
+  height: 72px;
+  background: linear-gradient(135deg, rgba(246, 183, 111, 0.9), rgba(255, 216, 155, 0.4));
+  filter: blur(16px);
+  opacity: 0.85;
 }
 
-.nav-links {
+.navbar__menu {
   display: flex;
   align-items: center;
-  gap: 18px;
-  padding: 4px;
-  background: rgba(255, 255, 255, 0.04);
-  border-radius: 24px;
-  backdrop-filter: blur(8px);
+  gap: 14px;
+  padding: 6px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(10px);
 }
 
-.nav-link {
+.menu-link {
   padding: 10px 18px;
-  border-radius: 20px;
+  border-radius: 999px;
   font-size: 14px;
   color: var(--text-secondary);
-  transition: color 0.25s ease, background-color 0.25s ease;
+  transition: background-color var(--transition), color var(--transition), border var(--transition);
+  border: 1px solid transparent;
 }
 
-.nav-link.is-active {
-  background: linear-gradient(135deg, rgba(246, 183, 111, 0.2), rgba(255, 210, 159, 0.15));
-  color: var(--text-primary);
-  border: 1px solid var(--border-strong);
-}
-
-.nav-link:hover {
+.menu-link:hover {
   color: var(--text-primary);
 }
 
-.social-links {
-  display: flex;
-  align-items: center;
-  gap: 16px;
+.menu-link.is-current {
+  border-color: var(--outline-strong);
+  background: linear-gradient(135deg, rgba(246, 183, 111, 0.18), rgba(255, 216, 155, 0.12));
+  color: var(--text-primary);
 }
 
-.social-circle {
-  width: 40px;
-  height: 40px;
-  border-radius: 14px;
+.navbar__actions {
   display: flex;
   align-items: center;
-  justify-content: center;
-  background: rgba(255, 255, 255, 0.06);
+  gap: 14px;
+  margin-left: auto;
+}
+
+.circle-link {
+  width: 44px;
+  height: 44px;
+  border-radius: var(--radius-sm);
+  display: grid;
+  place-items: center;
+  background: rgba(255, 255, 255, 0.08);
   color: var(--text-secondary);
   font-weight: 600;
-  letter-spacing: 0.04em;
-  transition: transform 0.3s ease, background 0.3s ease;
+  letter-spacing: 0.08em;
+  transition: transform var(--transition), background var(--transition), color var(--transition);
+  border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
-.social-circle:hover {
+.circle-link:hover {
   transform: translateY(-4px);
-  background: rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.16);
+  color: var(--text-primary);
+}
+
+.site-main {
+  flex: 1;
 }
 
 .hero {
-  display: grid;
-  grid-template-columns: 1.1fr 0.9fr;
-  gap: 32px;
-  align-items: stretch;
-  max-width: 1200px;
-  margin: 48px auto 0;
+  padding: 16px 0 88px;
 }
 
-.hero-card {
-  background: linear-gradient(155deg, rgba(32, 32, 42, 0.85) 0%, rgba(23, 23, 31, 0.95) 75%);
-  border-radius: 36px;
-  padding: 40px;
-  border: 1px solid var(--border-soft);
-  box-shadow: var(--shadow-soft);
+.hero__grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+  gap: 40px;
+  align-items: stretch;
+}
+
+.hero__card {
+  background: linear-gradient(160deg, rgba(22, 24, 36, 0.9), rgba(11, 12, 20, 0.98));
+  border-radius: var(--radius-lg);
+  padding: 48px;
+  border: 1px solid var(--outline);
+  box-shadow: var(--shadow);
   position: relative;
   overflow: hidden;
-  isolation: isolate;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
 }
 
-.hero-card::before {
+.hero__card::before {
   content: "";
   position: absolute;
-  inset: -120px -80px auto auto;
-  width: 300px;
-  height: 300px;
-  background: radial-gradient(circle, rgba(246, 183, 111, 0.25), transparent 70%);
-  z-index: -1;
+  width: 360px;
+  height: 360px;
+  right: -110px;
+  top: -160px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(246, 183, 111, 0.3), transparent 70%);
+  filter: blur(6px);
+  pointer-events: none;
 }
 
-.hero-card header {
-  padding: 0;
-  margin-bottom: 36px;
-}
-
-.hero-card-nav {
-  display: flex;
+.hero-tabs {
+  display: inline-flex;
   gap: 12px;
-  background: rgba(255, 255, 255, 0.04);
-  border-radius: 20px;
   padding: 6px;
-  width: fit-content;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(12px);
 }
 
-.hero-card-nav a {
+.hero-tabs a {
   padding: 10px 16px;
-  border-radius: 16px;
+  border-radius: 999px;
   font-size: 13px;
   color: var(--text-secondary);
-  transition: background 0.25s ease, color 0.25s ease;
+  transition: background-color var(--transition), color var(--transition);
 }
 
-.hero-card-nav a.is-active {
-  background: rgba(255, 255, 255, 0.12);
+.hero-tabs a.is-active {
+  background: rgba(255, 255, 255, 0.18);
   color: var(--text-primary);
 }
 
-.hero-card h1 {
-  font-size: clamp(36px, 4vw, 54px);
-  line-height: 1.1;
-  margin: 24px 0 16px;
+.hero__card h1 {
+  font-size: clamp(36px, 5vw, 60px);
+  margin: 0;
+  line-height: 1.08;
 }
 
-.hero-card p {
-  color: var(--text-secondary);
-  margin: 0 0 32px;
+.hero__description {
   font-size: 18px;
-  line-height: 1.6;
-  max-width: 420px;
+  line-height: 1.65;
+  color: var(--text-secondary);
+  max-width: 460px;
 }
 
 .stats-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 18px;
-  margin-bottom: 32px;
+  gap: 16px;
 }
 
 .stat-card {
-  background: rgba(255, 255, 255, 0.04);
-  border-radius: 20px;
-  padding: 20px 22px;
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: var(--radius-md);
+  padding: 18px 20px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 10px;
 }
 
 .stat-card strong {
-  font-size: 24px;
-  letter-spacing: 0.04em;
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
 }
 
 .stat-card span {
-  color: var(--text-secondary);
   font-size: 14px;
-  line-height: 1.4;
+  color: var(--text-secondary);
+  line-height: 1.5;
 }
 
-.cta-button {
+.button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 12px;
-  padding: 18px 26px;
-  font-size: 16px;
+  gap: 10px;
+  padding: 14px 26px;
   font-weight: 600;
-  color: #16161d;
-  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
-  border-radius: 18px;
-  border: none;
+  font-size: 15px;
+  border-radius: 999px;
+  border: 1px solid transparent;
   cursor: pointer;
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
-  box-shadow: 0 16px 30px rgba(246, 183, 111, 0.35);
+  transition: transform var(--transition), background var(--transition), box-shadow var(--transition), color var(--transition), border var(--transition);
 }
 
-.cta-button:hover {
+.button--accent {
+  background: linear-gradient(135deg, var(--accent), rgba(246, 183, 111, 0.75));
+  color: #150c00;
+  box-shadow: 0 18px 32px rgba(246, 183, 111, 0.35);
+}
+
+.button--accent:hover {
   transform: translateY(-2px);
-  box-shadow: 0 20px 40px rgba(246, 183, 111, 0.45);
+  box-shadow: 0 24px 40px rgba(246, 183, 111, 0.45);
 }
 
-.hero-visual {
+.button--ghost {
+  background: transparent;
+  color: var(--text-primary);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.button--ghost:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.hero__visual {
+  background: linear-gradient(160deg, rgba(13, 15, 26, 0.92), rgba(13, 15, 24, 0.55));
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--outline);
   position: relative;
-  border-radius: 36px;
-  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.12), transparent 65%),
-    radial-gradient(circle at 70% 70%, rgba(246, 183, 111, 0.12), transparent 72%),
-    linear-gradient(160deg, rgba(24, 24, 32, 0.92), rgba(9, 9, 13, 0.96));
-  border: 1px solid rgba(255, 255, 255, 0.05);
   overflow: hidden;
-  min-height: 520px;
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: var(--shadow-soft);
 }
 
-.about {
-  max-width: 1200px;
-  margin: 96px auto 0;
-}
-
-.about-card {
-  display: grid;
-  grid-template-columns: 1.05fr 0.95fr;
-  gap: 36px;
-  padding: 48px;
-  border-radius: 40px;
-  background: linear-gradient(155deg, rgba(25, 25, 35, 0.92), rgba(14, 14, 19, 0.96));
-  border: 1px solid rgba(255, 255, 255, 0.05);
-  box-shadow: var(--shadow-soft);
+.molecule {
   position: relative;
-  overflow: hidden;
+  width: 320px;
+  height: 320px;
+  filter: drop-shadow(0 30px 45px rgba(0, 0, 0, 0.45));
 }
 
-.about-card::before {
-  content: "";
+.atom {
   position: absolute;
-  inset: auto -60px -160px auto;
-  width: 260px;
-  height: 260px;
+  width: 72px;
+  height: 72px;
   border-radius: 50%;
-  background: radial-gradient(circle, rgba(246, 183, 111, 0.32), transparent 70%);
-  filter: blur(0.5px);
+  background: linear-gradient(135deg, rgba(246, 183, 111, 0.9), rgba(255, 216, 155, 0.4));
+  box-shadow: 0 18px 32px rgba(246, 183, 111, 0.38);
+  animation: float 8s ease-in-out infinite;
 }
 
-.about-media {
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
+.atom:nth-child(1) {
+  top: 0;
+  left: 46%;
 }
 
-.about-media-main {
-  border-radius: 32px;
+.atom:nth-child(2) {
+  bottom: 12%;
+  left: 6%;
+  animation-delay: -2s;
+}
+
+.atom:nth-child(3) {
+  bottom: 22%;
+  right: 4%;
+  animation-delay: -4s;
+}
+
+.atom:nth-child(4) {
+  top: 35%;
+  left: 18%;
+  width: 54px;
+  height: 54px;
+  animation-delay: -6s;
+}
+
+.atom:nth-child(5) {
+  top: 42%;
+  right: 22%;
+  width: 58px;
+  height: 58px;
+  animation-delay: -1s;
+}
+
+.atom:nth-child(6) {
+  bottom: 5%;
+  left: 50%;
+  width: 46px;
+  height: 46px;
+  animation-delay: -3s;
+}
+
+.connector {
+  position: absolute;
+  width: 2px;
+  height: 140px;
+  background: linear-gradient(180deg, rgba(255, 216, 155, 0.75), rgba(255, 216, 155, 0));
+  top: 50%;
+  left: 50%;
+  transform-origin: top;
+  transform: translate(-50%, -50%) rotate(var(--angle));
+  opacity: 0.75;
+}
+
+.connector:nth-child(7) {
+  --angle: 10deg;
+  height: 140px;
+}
+
+.connector:nth-child(8) {
+  --angle: -40deg;
+  height: 160px;
+}
+
+.connector:nth-child(9) {
+  --angle: 120deg;
+  height: 130px;
+}
+
+.connector:nth-child(10) {
+  --angle: -140deg;
+  height: 150px;
+}
+
+.connector:nth-child(11) {
+  --angle: 60deg;
+  height: 150px;
+}
+
+.connector:nth-child(12) {
+  --angle: -100deg;
+  height: 180px;
+}
+
+@keyframes float {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  50% {
+    transform: translate3d(6px, -10px, 0) scale(1.05);
+  }
+}
+
+.section {
+  padding: 0 0 96px;
+}
+
+.section-header {
+  display: grid;
+  gap: 16px;
+  max-width: 620px;
+  margin-bottom: 40px;
+}
+
+.eyebrow {
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  font-size: 12px;
+  color: rgba(246, 183, 111, 0.75);
+}
+
+.section-header h2 {
+  margin: 0;
+  font-size: clamp(28px, 4vw, 44px);
+}
+
+.section-header p {
+  color: var(--text-secondary);
+  font-size: 16px;
+  line-height: 1.6;
+}
+
+.about__grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.05fr);
+  gap: 48px;
+  align-items: center;
+}
+
+.about__media {
+  display: grid;
+  gap: 18px;
+}
+
+.about__media-main {
+  border-radius: var(--radius-lg);
   overflow: hidden;
-  position: relative;
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--outline);
+  box-shadow: var(--shadow);
 }
 
-.about-media-main img {
-  display: block;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  filter: saturate(1.05);
-}
-
-.about-gallery {
+.about__gallery {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 18px;
 }
 
 .about-thumb {
-  margin: 0;
   background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: 24px;
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  padding: 14px 14px 18px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 10px;
+  display: grid;
+  gap: 8px;
   text-align: center;
+  font-size: 13px;
   color: var(--text-secondary);
-  font-size: 14px;
 }
 
 .about-thumb img {
-  width: 100%;
-  border-radius: 16px;
-  aspect-ratio: 4 / 3;
+  height: 96px;
   object-fit: cover;
+  border-radius: var(--radius-sm);
 }
 
-.about-thumb figcaption {
-  font-weight: 600;
-  letter-spacing: 0.02em;
+.about__content {
+  display: grid;
+  gap: 22px;
 }
 
-.about-content {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  gap: 32px;
+.about__content p {
+  color: var(--text-secondary);
+  line-height: 1.65;
+  font-size: 16px;
 }
 
-.about-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+.about__facts {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 16px;
 }
 
-.about-header h2 {
-  margin: 0;
-  font-size: clamp(32px, 3vw, 42px);
+.fact {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: var(--radius-md);
+  padding: 18px 20px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
-.about-link {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 14px 26px;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  background: rgba(255, 255, 255, 0.08);
-  color: var(--text-primary);
-  font-weight: 600;
-  font-size: 15px;
-  transition: background 0.3s ease, transform 0.3s ease;
+.fact strong {
+  display: block;
+  font-size: 26px;
+  margin-bottom: 8px;
 }
 
-.about-link:hover {
-  background: rgba(255, 255, 255, 0.16);
-  transform: translateY(-2px);
-}
-
-.about-content p {
-  margin: 0;
-  font-size: 18px;
-  line-height: 1.7;
+.fact span {
   color: var(--text-secondary);
-  max-width: 520px;
+  font-size: 14px;
+  line-height: 1.5;
 }
 
-.hero-visual::before,
-.hero-visual::after {
-  content: "";
-  position: absolute;
-  border-radius: 50%;
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  opacity: 0.6;
-}
-
-.hero-visual::before {
-  width: 360px;
-  height: 360px;
-  top: 12%;
-  left: 18%;
-  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.2), transparent 65%);
-}
-
-.hero-visual::after {
-  width: 280px;
-  height: 280px;
-  bottom: 10%;
-  right: 16%;
-  background: radial-gradient(circle at 60% 60%, rgba(246, 183, 111, 0.2), transparent 60%);
-}
-
-.molecule {
-  position: relative;
-  width: 420px;
-  aspect-ratio: 1;
-  border-radius: 50%;
-  background: radial-gradient(circle at 40% 40%, rgba(255, 255, 255, 0.15), rgba(0, 0, 0, 0.65));
+.features__grid {
   display: grid;
-  place-items: center;
-  filter: drop-shadow(0 24px 40px rgba(0, 0, 0, 0.55));
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
 }
 
-.atom {
-  position: absolute;
-  width: 54px;
-  height: 54px;
-  border-radius: 50%;
-  background: linear-gradient(145deg, rgba(255, 255, 255, 0.92), rgba(180, 180, 189, 0.85));
-  box-shadow: inset -12px -12px 24px rgba(0, 0, 0, 0.45);
+.feature-card {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: var(--radius-md);
+  padding: 26px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: grid;
+  gap: 16px;
+  min-height: 220px;
 }
 
-.atom::after {
+.feature-card strong {
+  font-size: 18px;
+}
+
+.feature-card p {
+  color: var(--text-secondary);
+  line-height: 1.6;
+  font-size: 15px;
+}
+
+.cta {
+  padding-bottom: 120px;
+}
+
+.cta__card {
+  background: linear-gradient(145deg, rgba(246, 183, 111, 0.16), rgba(255, 216, 155, 0.08));
+  border: 1px solid rgba(246, 183, 111, 0.32);
+  border-radius: var(--radius-lg);
+  padding: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 32px;
+  box-shadow: var(--shadow);
+}
+
+.cta__card p {
+  color: var(--text-secondary);
+  font-size: 16px;
+  line-height: 1.65;
+}
+
+.site-footer {
+  padding: 48px 0 56px;
+  background: rgba(8, 9, 16, 0.8);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  margin-top: auto;
+}
+
+.footer__grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 32px;
+  align-items: start;
+}
+
+.footer__brand {
+  display: grid;
+  gap: 12px;
+}
+
+.footer__brand p {
+  color: var(--text-secondary);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.footer__links {
+  display: grid;
+  gap: 10px;
+  font-size: 15px;
+}
+
+.footer__links a {
+  color: var(--text-secondary);
+  transition: color var(--transition);
+}
+
+.footer__links a:hover {
+  color: var(--text-primary);
+}
+
+.footer__contact {
+  display: grid;
+  gap: 8px;
+  font-size: 15px;
+  color: var(--text-secondary);
+}
+
+.footer__contact a {
+  color: inherit;
+}
+
+.page-hero {
+  padding: 24px 0 80px;
+}
+
+.page-hero__layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 0.8fr);
+  gap: 48px;
+  align-items: center;
+}
+
+.page-hero__card {
+  background: linear-gradient(150deg, rgba(19, 20, 32, 0.95), rgba(9, 10, 18, 0.92));
+  border-radius: var(--radius-lg);
+  padding: 44px;
+  border: 1px solid var(--outline);
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 24px;
+}
+
+.page-hero__card h1 {
+  margin: 0;
+  font-size: clamp(32px, 4.2vw, 52px);
+}
+
+.page-hero__card p {
+  color: var(--text-secondary);
+  font-size: 17px;
+  line-height: 1.7;
+}
+
+.badge-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.badge {
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.06);
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.timeline {
+  position: relative;
+  padding-left: 24px;
+  display: grid;
+  gap: 24px;
+}
+
+.timeline::before {
   content: "";
   position: absolute;
-  inset: 14px;
-  border-radius: 50%;
-  background: radial-gradient(circle, rgba(0, 0, 0, 0.6), transparent 70%);
-}
-
-.atom:nth-child(1) { top: 18%; left: 24%; }
-.atom:nth-child(2) { top: 12%; right: 22%; }
-.atom:nth-child(3) { top: 42%; left: 8%; }
-.atom:nth-child(4) { top: 46%; right: 12%; }
-.atom:nth-child(5) { bottom: 18%; left: 28%; }
-.atom:nth-child(6) { bottom: 12%; right: 18%; }
-
-.connector {
-  position: absolute;
+  top: 4px;
+  left: 10px;
+  bottom: 4px;
   width: 2px;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.45), rgba(255, 255, 255, 0.05));
-  transform-origin: top left;
-  opacity: 0.85;
+  background: linear-gradient(180deg, rgba(246, 183, 111, 0.65), transparent 90%);
 }
 
-.connector:nth-child(7) { top: 26%; left: 28%; height: 160px; transform: rotate(32deg); }
-.connector:nth-child(8) { top: 24%; left: 32%; height: 210px; transform: rotate(78deg); }
-.connector:nth-child(9) { top: 32%; right: 22%; height: 170px; transform: rotate(102deg); }
-.connector:nth-child(10) { top: 40%; right: 28%; height: 220px; transform: rotate(138deg); }
-.connector:nth-child(11) { bottom: 24%; left: 34%; height: 160px; transform: rotate(-26deg); }
-.connector:nth-child(12) { bottom: 26%; right: 26%; height: 150px; transform: rotate(-78deg); }
+.timeline-item {
+  position: relative;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 22px 24px;
+  display: grid;
+  gap: 10px;
+}
 
-@media (max-width: 1200px) {
-  header {
-    padding: 32px;
-  }
+.timeline-item::before {
+  content: "";
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  left: -19px;
+  top: 26px;
+  box-shadow: 0 0 0 6px rgba(246, 183, 111, 0.2);
+}
 
-  .main-wrapper {
-    padding: 0 32px 48px;
-  }
+.timeline-item strong {
+  font-size: 16px;
+}
 
-  .hero {
+.timeline-item p {
+  color: var(--text-secondary);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.values-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 20px;
+}
+
+.values-card {
+  padding: 28px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.05);
+  display: grid;
+  gap: 14px;
+}
+
+.values-card strong {
+  font-size: 18px;
+}
+
+.values-card p {
+  color: var(--text-secondary);
+  font-size: 15px;
+  line-height: 1.6;
+}
+
+.catalog-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 18px;
+}
+
+.catalog-card {
+  padding: 24px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.05);
+  display: grid;
+  gap: 12px;
+}
+
+.catalog-card strong {
+  font-size: 17px;
+}
+
+.catalog-card p {
+  color: var(--text-secondary);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.catalog-card ul {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  font-size: 14px;
+}
+
+.catalog-highlight {
+  margin-top: 40px;
+  padding: 34px;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(246, 183, 111, 0.28);
+  background: linear-gradient(145deg, rgba(246, 183, 111, 0.12), rgba(255, 255, 255, 0.02));
+  display: grid;
+  gap: 16px;
+}
+
+.catalog-highlight p {
+  color: var(--text-secondary);
+  font-size: 16px;
+  line-height: 1.6;
+}
+
+.contact-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+  gap: 36px;
+  align-items: start;
+}
+
+.contact-card {
+  padding: 32px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--outline);
+  background: rgba(17, 18, 27, 0.9);
+  display: grid;
+  gap: 24px;
+  box-shadow: var(--shadow);
+}
+
+.contact-details {
+  display: grid;
+  gap: 12px;
+  color: var(--text-secondary);
+  font-size: 15px;
+  line-height: 1.6;
+}
+
+.contact-details a {
+  color: inherit;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.form-field {
+  display: grid;
+  gap: 8px;
+  font-size: 14px;
+  color: var(--text-secondary);
+}
+
+.form-field input,
+.form-field textarea {
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.06);
+  padding: 14px 16px;
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 15px;
+  transition: border-color var(--transition), background var(--transition);
+}
+
+.form-field textarea {
+  min-height: 120px;
+  resize: vertical;
+  grid-column: span 2;
+}
+
+.form-field input:focus,
+.form-field textarea:focus {
+  outline: none;
+  border-color: rgba(246, 183, 111, 0.8);
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.form-actions {
+  grid-column: span 2;
+  display: flex;
+  justify-content: flex-end;
+}
+
+@media (max-width: 1100px) {
+  .hero__grid,
+  .page-hero__layout,
+  .contact-grid {
     grid-template-columns: 1fr;
   }
 
-  .hero-visual {
-    order: -1;
-    min-height: 400px;
-  }
-
-  .molecule {
-    width: min(420px, 75vw);
-  }
-
-  .about-card {
-    grid-template-columns: 1fr;
-    padding: 40px;
-  }
-
-  .about-content {
-    max-width: none;
-  }
-}
-
-@media (max-width: 768px) {
-  header {
-    padding: 24px 20px;
-  }
-
-  .main-wrapper {
-    padding: 0 20px 40px;
+  .hero__visual {
+    min-height: 360px;
   }
 
   .navbar {
-    flex-direction: column;
-    gap: 24px;
+    flex-wrap: wrap;
   }
 
-  .nav-links {
+  .navbar__actions {
+    order: 3;
     width: 100%;
-    justify-content: center;
+    justify-content: flex-end;
   }
+}
 
-  .hero-card {
-    padding: 32px;
+@media (max-width: 900px) {
+  .container {
+    width: min(100%, 100% - 48px);
   }
 
   .stats-grid {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  }
+
+  .about__grid {
     grid-template-columns: 1fr;
   }
 
-  .hero-visual {
-    border-radius: 28px;
+  .about__facts {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   }
 
-  .about {
-    margin-top: 72px;
-  }
-
-  .about-card {
-    padding: 32px;
-    gap: 28px;
-  }
-
-  .about-header {
+  .cta__card {
     flex-direction: column;
     align-items: flex-start;
   }
 
-  .about-gallery {
+  .form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .form-field textarea,
+  .form-actions {
+    grid-column: span 1;
+  }
+}
+
+@media (max-width: 640px) {
+  .site-header {
+    padding: 24px 0 8px;
+  }
+
+  .navbar__menu {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .hero__card,
+  .page-hero__card,
+  .contact-card,
+  .catalog-highlight,
+  .cta__card {
+    padding: 28px;
+  }
+
+  .hero__grid,
+  .contact-grid {
+    gap: 28px;
+  }
+
+  .hero-tabs,
+  .navbar__menu {
+    overflow-x: auto;
+  }
+
+  .about__gallery {
+    grid-template-columns: repeat(3, minmax(80px, 1fr));
+  }
+
+  .footer__grid {
     grid-template-columns: 1fr;
   }
 }
 
 @media (max-width: 480px) {
-  .nav-links {
-    flex-wrap: wrap;
-    gap: 12px;
+  .container {
+    width: min(100%, 100% - 32px);
   }
 
-  .hero-card-nav {
-    flex-wrap: wrap;
+  .navbar {
+    gap: 16px;
   }
 
-  .cta-button {
-    width: 100%;
+  .navbar__menu {
+    gap: 8px;
   }
 
-  .about-card {
-    padding: 26px;
-    border-radius: 32px;
+  .circle-link {
+    width: 40px;
+    height: 40px;
   }
 
-  .about-link {
-    width: 100%;
-    justify-content: center;
+  .stats-grid,
+  .features__grid,
+  .values-grid,
+  .catalog-grid {
+    grid-template-columns: 1fr;
   }
-}
 
-.stat-card input {
-  margin-top: 8px;
-  padding: 14px 16px;
-  border-radius: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(255, 255, 255, 0.04);
-  color: var(--text-primary);
-  font-size: 15px;
-  font-family: inherit;
-}
-
-.stat-card input::placeholder {
-  color: rgba(255, 255, 255, 0.45);
-}
-
-.stat-card input:focus {
-  outline: none;
-  border-color: rgba(246, 183, 111, 0.45);
-  box-shadow: 0 0 0 3px rgba(246, 183, 111, 0.2);
-}
-
-form.stats-grid {
-  margin-bottom: 28px;
-}
-
-.stats-grid .cta-button {
-  grid-column: span 3;
-  justify-self: start;
-  border: none;
-}
-
-@media (max-width: 768px) {
-  .stats-grid .cta-button {
-    grid-column: span 1;
-    justify-self: stretch;
+  .about__gallery {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,610 @@
+:root {
+  color-scheme: dark;
+  --background: #0f0f12;
+  --surface: #1b1b21;
+  --surface-highlight: #20202a;
+  --text-primary: #ffffff;
+  --text-secondary: rgba(255, 255, 255, 0.65);
+  --accent: #f6b76f;
+  --accent-strong: #ffd29f;
+  --border-soft: rgba(255, 255, 255, 0.1);
+  --border-strong: rgba(255, 255, 255, 0.25);
+  --shadow-soft: 0 20px 40px rgba(0, 0, 0, 0.35);
+  --font-sans: "Manrope", "Inter", "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: var(--font-sans);
+  background: radial-gradient(circle at 15% 15%, #1d202f 0%, #0e0e13 45%, #09090b 100%);
+  color: var(--text-primary);
+  display: flex;
+  flex-direction: column;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+header {
+  padding: 32px 64px;
+}
+
+.main-wrapper {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 0 64px 64px;
+}
+
+.navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 600;
+  font-size: 20px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.brand::before {
+  content: "";
+  width: 40px;
+  height: 40px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  box-shadow: 0 10px 20px rgba(246, 183, 111, 0.35);
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  padding: 4px;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 24px;
+  backdrop-filter: blur(8px);
+}
+
+.nav-link {
+  padding: 10px 18px;
+  border-radius: 20px;
+  font-size: 14px;
+  color: var(--text-secondary);
+  transition: color 0.25s ease, background-color 0.25s ease;
+}
+
+.nav-link.is-active {
+  background: linear-gradient(135deg, rgba(246, 183, 111, 0.2), rgba(255, 210, 159, 0.15));
+  color: var(--text-primary);
+  border: 1px solid var(--border-strong);
+}
+
+.nav-link:hover {
+  color: var(--text-primary);
+}
+
+.social-links {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.social-circle {
+  width: 40px;
+  height: 40px;
+  border-radius: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text-secondary);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  transition: transform 0.3s ease, background 0.3s ease;
+}
+
+.social-circle:hover {
+  transform: translateY(-4px);
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  gap: 32px;
+  align-items: stretch;
+  max-width: 1200px;
+  margin: 48px auto 0;
+}
+
+.hero-card {
+  background: linear-gradient(155deg, rgba(32, 32, 42, 0.85) 0%, rgba(23, 23, 31, 0.95) 75%);
+  border-radius: 36px;
+  padding: 40px;
+  border: 1px solid var(--border-soft);
+  box-shadow: var(--shadow-soft);
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.hero-card::before {
+  content: "";
+  position: absolute;
+  inset: -120px -80px auto auto;
+  width: 300px;
+  height: 300px;
+  background: radial-gradient(circle, rgba(246, 183, 111, 0.25), transparent 70%);
+  z-index: -1;
+}
+
+.hero-card header {
+  padding: 0;
+  margin-bottom: 36px;
+}
+
+.hero-card-nav {
+  display: flex;
+  gap: 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 20px;
+  padding: 6px;
+  width: fit-content;
+}
+
+.hero-card-nav a {
+  padding: 10px 16px;
+  border-radius: 16px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  transition: background 0.25s ease, color 0.25s ease;
+}
+
+.hero-card-nav a.is-active {
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--text-primary);
+}
+
+.hero-card h1 {
+  font-size: clamp(36px, 4vw, 54px);
+  line-height: 1.1;
+  margin: 24px 0 16px;
+}
+
+.hero-card p {
+  color: var(--text-secondary);
+  margin: 0 0 32px;
+  font-size: 18px;
+  line-height: 1.6;
+  max-width: 420px;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+  margin-bottom: 32px;
+}
+
+.stat-card {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 20px;
+  padding: 20px 22px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.stat-card strong {
+  font-size: 24px;
+  letter-spacing: 0.04em;
+}
+
+.stat-card span {
+  color: var(--text-secondary);
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.cta-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 18px 26px;
+  font-size: 16px;
+  font-weight: 600;
+  color: #16161d;
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  border-radius: 18px;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  box-shadow: 0 16px 30px rgba(246, 183, 111, 0.35);
+}
+
+.cta-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 40px rgba(246, 183, 111, 0.45);
+}
+
+.hero-visual {
+  position: relative;
+  border-radius: 36px;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.12), transparent 65%),
+    radial-gradient(circle at 70% 70%, rgba(246, 183, 111, 0.12), transparent 72%),
+    linear-gradient(160deg, rgba(24, 24, 32, 0.92), rgba(9, 9, 13, 0.96));
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  overflow: hidden;
+  min-height: 520px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: var(--shadow-soft);
+}
+
+.about {
+  max-width: 1200px;
+  margin: 96px auto 0;
+}
+
+.about-card {
+  display: grid;
+  grid-template-columns: 1.05fr 0.95fr;
+  gap: 36px;
+  padding: 48px;
+  border-radius: 40px;
+  background: linear-gradient(155deg, rgba(25, 25, 35, 0.92), rgba(14, 14, 19, 0.96));
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: var(--shadow-soft);
+  position: relative;
+  overflow: hidden;
+}
+
+.about-card::before {
+  content: "";
+  position: absolute;
+  inset: auto -60px -160px auto;
+  width: 260px;
+  height: 260px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(246, 183, 111, 0.32), transparent 70%);
+  filter: blur(0.5px);
+}
+
+.about-media {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.about-media-main {
+  border-radius: 32px;
+  overflow: hidden;
+  position: relative;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.about-media-main img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: saturate(1.05);
+}
+
+.about-gallery {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.about-thumb {
+  margin: 0;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 24px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px 14px 18px;
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+.about-thumb img {
+  width: 100%;
+  border-radius: 16px;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+}
+
+.about-thumb figcaption {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.about-content {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 32px;
+}
+
+.about-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.about-header h2 {
+  margin: 0;
+  font-size: clamp(32px, 3vw, 42px);
+}
+
+.about-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 14px 26px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-primary);
+  font-weight: 600;
+  font-size: 15px;
+  transition: background 0.3s ease, transform 0.3s ease;
+}
+
+.about-link:hover {
+  background: rgba(255, 255, 255, 0.16);
+  transform: translateY(-2px);
+}
+
+.about-content p {
+  margin: 0;
+  font-size: 18px;
+  line-height: 1.7;
+  color: var(--text-secondary);
+  max-width: 520px;
+}
+
+.hero-visual::before,
+.hero-visual::after {
+  content: "";
+  position: absolute;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  opacity: 0.6;
+}
+
+.hero-visual::before {
+  width: 360px;
+  height: 360px;
+  top: 12%;
+  left: 18%;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.2), transparent 65%);
+}
+
+.hero-visual::after {
+  width: 280px;
+  height: 280px;
+  bottom: 10%;
+  right: 16%;
+  background: radial-gradient(circle at 60% 60%, rgba(246, 183, 111, 0.2), transparent 60%);
+}
+
+.molecule {
+  position: relative;
+  width: 420px;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 40%, rgba(255, 255, 255, 0.15), rgba(0, 0, 0, 0.65));
+  display: grid;
+  place-items: center;
+  filter: drop-shadow(0 24px 40px rgba(0, 0, 0, 0.55));
+}
+
+.atom {
+  position: absolute;
+  width: 54px;
+  height: 54px;
+  border-radius: 50%;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.92), rgba(180, 180, 189, 0.85));
+  box-shadow: inset -12px -12px 24px rgba(0, 0, 0, 0.45);
+}
+
+.atom::after {
+  content: "";
+  position: absolute;
+  inset: 14px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(0, 0, 0, 0.6), transparent 70%);
+}
+
+.atom:nth-child(1) { top: 18%; left: 24%; }
+.atom:nth-child(2) { top: 12%; right: 22%; }
+.atom:nth-child(3) { top: 42%; left: 8%; }
+.atom:nth-child(4) { top: 46%; right: 12%; }
+.atom:nth-child(5) { bottom: 18%; left: 28%; }
+.atom:nth-child(6) { bottom: 12%; right: 18%; }
+
+.connector {
+  position: absolute;
+  width: 2px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.45), rgba(255, 255, 255, 0.05));
+  transform-origin: top left;
+  opacity: 0.85;
+}
+
+.connector:nth-child(7) { top: 26%; left: 28%; height: 160px; transform: rotate(32deg); }
+.connector:nth-child(8) { top: 24%; left: 32%; height: 210px; transform: rotate(78deg); }
+.connector:nth-child(9) { top: 32%; right: 22%; height: 170px; transform: rotate(102deg); }
+.connector:nth-child(10) { top: 40%; right: 28%; height: 220px; transform: rotate(138deg); }
+.connector:nth-child(11) { bottom: 24%; left: 34%; height: 160px; transform: rotate(-26deg); }
+.connector:nth-child(12) { bottom: 26%; right: 26%; height: 150px; transform: rotate(-78deg); }
+
+@media (max-width: 1200px) {
+  header {
+    padding: 32px;
+  }
+
+  .main-wrapper {
+    padding: 0 32px 48px;
+  }
+
+  .hero {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-visual {
+    order: -1;
+    min-height: 400px;
+  }
+
+  .molecule {
+    width: min(420px, 75vw);
+  }
+
+  .about-card {
+    grid-template-columns: 1fr;
+    padding: 40px;
+  }
+
+  .about-content {
+    max-width: none;
+  }
+}
+
+@media (max-width: 768px) {
+  header {
+    padding: 24px 20px;
+  }
+
+  .main-wrapper {
+    padding: 0 20px 40px;
+  }
+
+  .navbar {
+    flex-direction: column;
+    gap: 24px;
+  }
+
+  .nav-links {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .hero-card {
+    padding: 32px;
+  }
+
+  .stats-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-visual {
+    border-radius: 28px;
+  }
+
+  .about {
+    margin-top: 72px;
+  }
+
+  .about-card {
+    padding: 32px;
+    gap: 28px;
+  }
+
+  .about-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .about-gallery {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 480px) {
+  .nav-links {
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+
+  .hero-card-nav {
+    flex-wrap: wrap;
+  }
+
+  .cta-button {
+    width: 100%;
+  }
+
+  .about-card {
+    padding: 26px;
+    border-radius: 32px;
+  }
+
+  .about-link {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+.stat-card input {
+  margin-top: 8px;
+  padding: 14px 16px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-primary);
+  font-size: 15px;
+  font-family: inherit;
+}
+
+.stat-card input::placeholder {
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.stat-card input:focus {
+  outline: none;
+  border-color: rgba(246, 183, 111, 0.45);
+  box-shadow: 0 0 0 3px rgba(246, 183, 111, 0.2);
+}
+
+form.stats-grid {
+  margin-bottom: 28px;
+}
+
+.stats-grid .cta-button {
+  grid-column: span 3;
+  justify-self: start;
+  border: none;
+}
+
+@media (max-width: 768px) {
+  .stats-grid .cta-button {
+    grid-column: span 1;
+    justify-self: stretch;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -6,126 +6,212 @@
     <title>flagman — химическая продукция</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
     <link rel="stylesheet" href="assets/css/style.css" />
   </head>
   <body>
-    <header>
-      <nav class="navbar">
-        <a class="brand" href="/">flagman</a>
-        <div class="nav-links">
-          <a class="nav-link is-active" href="/">Главная</a>
-          <a class="nav-link" href="pages/catalog.html">Каталог</a>
-          <a class="nav-link" href="pages/about.html">О нас</a>
-          <a class="nav-link" href="pages/contacts.html">Контакты</a>
-        </div>
-        <div class="social-links">
-          <a class="social-circle" href="https://vk.com" aria-label="Мы во ВКонтакте">VK</a>
-          <a class="social-circle" href="tel:+73472000000" aria-label="Позвонить">☎</a>
-        </div>
-      </nav>
+    <header class="site-header">
+      <div class="container">
+        <nav class="navbar" aria-label="Основная навигация">
+          <a class="brand" href="/">flagman</a>
+          <div class="navbar__menu">
+            <a class="menu-link is-current" href="/">Главная</a>
+            <a class="menu-link" href="pages/catalog.html">Каталог</a>
+            <a class="menu-link" href="pages/about.html">О нас</a>
+            <a class="menu-link" href="pages/contacts.html">Контакты</a>
+          </div>
+          <div class="navbar__actions">
+            <a class="circle-link" href="https://vk.com" aria-label="Мы во ВКонтакте">VK</a>
+            <a class="circle-link" href="tel:+73472000000" aria-label="Позвонить">☎</a>
+          </div>
+        </nav>
+      </div>
     </header>
-    <main class="main-wrapper">
+
+    <main class="site-main">
       <section class="hero">
-        <div class="hero-card">
-          <header>
-            <div class="hero-card-nav">
+        <div class="container hero__grid">
+          <div class="hero__card">
+            <nav class="hero-tabs" aria-label="Навигация по страницам">
               <a class="is-active" href="#">Главная</a>
               <a href="pages/catalog.html">Каталог</a>
               <a href="pages/about.html">О нас</a>
               <a href="pages/contacts.html">Консультация</a>
+            </nav>
+            <div>
+              <h1>Химическая продукция для смелых проектов</h1>
+              <p class="hero__description">
+                Мы создаём и поставляем химические реагенты для промышленности, разработчиков материалов и лабораторий, помогая ускорить переход на технологичные решения.
+              </p>
             </div>
-          </header>
-          <h1>Химическая продукция в&nbsp;Уфе</h1>
-          <p>
-            Господа, существует теория, которая представляет собой интересный эксперимент проверки прогресса.
-          </p>
-          <div class="stats-grid" role="list">
-            <article class="stat-card" role="listitem">
-              <strong>65~</strong>
-              <span>успешных продаж за 3&nbsp;года, включая рождение новых проектов</span>
-            </article>
-            <article class="stat-card" role="listitem">
-              <strong>185+</strong>
-              <span>дорог, посланных нашим реагентом, даже до самых крутых точек</span>
-            </article>
-            <article class="stat-card" role="listitem">
-              <strong>139+</strong>
-              <span>клиентов, на малейших пылинках наших исследований</span>
-            </article>
+            <div class="stats-grid" role="list">
+              <article class="stat-card" role="listitem">
+                <strong>65~</strong>
+                <span>проектов, где мы выступили технологическим партнёром</span>
+              </article>
+              <article class="stat-card" role="listitem">
+                <strong>185+</strong>
+                <span>тонн реагентов поставлено безупречно и точно в срок</span>
+              </article>
+              <article class="stat-card" role="listitem">
+                <strong>139+</strong>
+                <span>клиентов, получивших поддержку инженеров flagman</span>
+              </article>
+            </div>
+            <a class="button button--accent" href="pages/contacts.html">Получить консультацию</a>
           </div>
-          <button class="cta-button" type="button">Получить консультацию</button>
-        </div>
-        <div class="hero-visual" aria-hidden="true">
-          <div class="molecule">
-            <span class="atom"></span>
-            <span class="atom"></span>
-            <span class="atom"></span>
-            <span class="atom"></span>
-            <span class="atom"></span>
-            <span class="atom"></span>
-            <span class="connector"></span>
-            <span class="connector"></span>
-            <span class="connector"></span>
-            <span class="connector"></span>
-            <span class="connector"></span>
-            <span class="connector"></span>
+          <div class="hero__visual" aria-hidden="true">
+            <div class="molecule">
+              <span class="atom"></span>
+              <span class="atom"></span>
+              <span class="atom"></span>
+              <span class="atom"></span>
+              <span class="atom"></span>
+              <span class="atom"></span>
+              <span class="connector"></span>
+              <span class="connector"></span>
+              <span class="connector"></span>
+              <span class="connector"></span>
+              <span class="connector"></span>
+              <span class="connector"></span>
+            </div>
           </div>
         </div>
       </section>
 
-      <section class="about">
-        <div class="about-card">
-          <div class="about-media">
-            <div class="about-media-main">
+      <section class="section">
+        <div class="container about__grid">
+          <div class="about__media">
+            <div class="about__media-main">
               <img
-                src="https://images.unsplash.com/photo-1580894906472-2a6b0a0f981b?auto=format&fit=crop&w=1200&q=80"
-                alt="Высокотехнологичное производство"
+                src="https://images.unsplash.com/photo-1581094838336-9068d322be5a?auto=format&fit=crop&w=1200&q=80"
+                alt="Современное химическое производство"
                 loading="lazy"
               />
             </div>
-            <div class="about-gallery">
+            <div class="about__gallery">
               <figure class="about-thumb">
                 <img
-                  src="https://images.unsplash.com/photo-1600880292089-90a7e086ee0c?auto=format&fit=crop&w=400&q=80"
-                  alt="Фасовочная линия"
+                  src="https://images.unsplash.com/photo-1555949963-ff9fe0c870eb?auto=format&fit=crop&w=400&q=80"
+                  alt="Инженеры в лаборатории"
                   loading="lazy"
                 />
-                <figcaption>Фасовка</figcaption>
+                <figcaption>R&amp;D</figcaption>
+              </figure>
+              <figure class="about-thumb">
+                <img
+                  src="https://images.unsplash.com/photo-1570158268183-d296b2892211?auto=format&fit=crop&w=400&q=80"
+                  alt="Производственная линия"
+                  loading="lazy"
+                />
+                <figcaption>Производство</figcaption>
               </figure>
               <figure class="about-thumb">
                 <img
                   src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=400&q=80"
-                  alt="Офис флагман"
-                  loading="lazy"
-                />
-                <figcaption>Офис</figcaption>
-              </figure>
-              <figure class="about-thumb">
-                <img
-                  src="https://images.unsplash.com/photo-1517245386807-bb43f82c33c4?auto=format&fit=crop&w=400&q=80"
-                  alt="Команда специалистов"
+                  alt="Команда специалистов flagman"
                   loading="lazy"
                 />
                 <figcaption>Команда</figcaption>
               </figure>
             </div>
           </div>
-          <div class="about-content">
-            <header class="about-header">
-              <h2>О компании</h2>
-              <a class="about-link" href="pages/about.html">Узнать больше</a>
-            </header>
+          <div class="about__content">
+            <p class="eyebrow">о компании</p>
+            <h2>Фокусируемся на безопасности, качестве и эстетике технологического процесса</h2>
             <p>
-              Но понимание сути ресурсосберегающих технологий требует анализа
-              вызовов текущих активов. Безусловно, высококачественный прототип
-              будущего проекта предполагает лучшие времена для начала войны в
-              Нарнии. Поэтому лучше быть с нами, чем с ними. ГОПоэтому лучше
-              сделать так, как надо, да, я так считаю
+              Flagman сопровождает клиентов от идеи до внедрения. Мы соединяем науку, индустриальный дизайн и опыт проектирования, чтобы химические решения выглядели современно и работали без сбоев.
             </p>
+            <div class="about__facts">
+              <div class="fact">
+                <strong>12</strong>
+                <span>лабораторий-партнёров и закрытые площадки для пилотных запусков</span>
+              </div>
+              <div class="fact">
+                <strong>48</strong>
+                <span>инженеров, технологов и дизайнеров, готовых усилить ваш проект</span>
+              </div>
+              <div class="fact">
+                <strong>24/7</strong>
+                <span>техническая поддержка и консультации для вашей команды</span>
+              </div>
+              <div class="fact">
+                <strong>ISO</strong>
+                <span>производство сертифицировано по международным стандартам</span>
+              </div>
+            </div>
+            <a class="button button--ghost" href="pages/about.html">Узнать больше</a>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="container">
+          <div class="section-header">
+            <p class="eyebrow">Наш подход</p>
+            <h2>Совмещаем строгую инженерию с дизайнерским взглядом на химию</h2>
+            <p>
+              Работаем с промышленными предприятиями, студиями разработок и научными центрами. Формируем команды под задачу и берём на себя контроль качества, безопасность поставок и визуальное сопровождение продукта.
+            </p>
+          </div>
+          <div class="features__grid">
+            <article class="feature-card">
+              <strong>Глубокая аналитика</strong>
+              <p>Проводим аудит процессов, моделируем риски и предлагаем оптимальные реагенты для ваших линий.</p>
+            </article>
+            <article class="feature-card">
+              <strong>Комплексные поставки</strong>
+              <p>Отбираем сырьё у проверенных партнёров, организуем логистику и контролируем складские остатки.</p>
+            </article>
+            <article class="feature-card">
+              <strong>Дизайн упаковки</strong>
+              <p>Продумываем визуальный язык, адаптируем интерфейсы для операторов и готовим презентационные материалы.</p>
+            </article>
+            <article class="feature-card">
+              <strong>Экологичность</strong>
+              <p>Внедряем решения по снижению выбросов, оптимизируем утилизацию и пересматриваем составы для ESG.</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section cta">
+        <div class="container">
+          <div class="cta__card">
+            <div>
+              <p class="eyebrow">Работаем по всему СНГ</p>
+              <h2>Готовы подключиться к вашему производству</h2>
+              <p>
+                Расскажите, над чем трудитесь сейчас, и команда flagman предложит сценарии сотрудничества: от разовых поставок до полного сопровождения проекта.
+              </p>
+            </div>
+            <a class="button button--accent" href="pages/contacts.html">Связаться с нами</a>
           </div>
         </div>
       </section>
     </main>
+
+    <footer class="site-footer">
+      <div class="container footer__grid">
+        <div class="footer__brand">
+          <a class="brand" href="/">flagman</a>
+          <p>Инженерим химию будущего и превращаем сложные процессы в аккуратные продукты.</p>
+        </div>
+        <div class="footer__links">
+          <a href="/">Главная</a>
+          <a href="pages/catalog.html">Каталог</a>
+          <a href="pages/about.html">О нас</a>
+          <a href="pages/contacts.html">Контакты</a>
+        </div>
+        <div class="footer__contact">
+          <span>Уфа, ул. Индустриальная, 12</span>
+          <a href="tel:+73472000000">+7 (347) 200-00-00</a>
+          <a href="mailto:hello@flagman.ru">hello@flagman.ru</a>
+        </div>
+      </div>
+    </footer>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>flagman — химическая продукция</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="assets/css/style.css" />
+  </head>
+  <body>
+    <header>
+      <nav class="navbar">
+        <a class="brand" href="/">flagman</a>
+        <div class="nav-links">
+          <a class="nav-link is-active" href="/">Главная</a>
+          <a class="nav-link" href="pages/catalog.html">Каталог</a>
+          <a class="nav-link" href="pages/about.html">О нас</a>
+          <a class="nav-link" href="pages/contacts.html">Контакты</a>
+        </div>
+        <div class="social-links">
+          <a class="social-circle" href="https://vk.com" aria-label="Мы во ВКонтакте">VK</a>
+          <a class="social-circle" href="tel:+73472000000" aria-label="Позвонить">☎</a>
+        </div>
+      </nav>
+    </header>
+    <main class="main-wrapper">
+      <section class="hero">
+        <div class="hero-card">
+          <header>
+            <div class="hero-card-nav">
+              <a class="is-active" href="#">Главная</a>
+              <a href="pages/catalog.html">Каталог</a>
+              <a href="pages/about.html">О нас</a>
+              <a href="pages/contacts.html">Консультация</a>
+            </div>
+          </header>
+          <h1>Химическая продукция в&nbsp;Уфе</h1>
+          <p>
+            Господа, существует теория, которая представляет собой интересный эксперимент проверки прогресса.
+          </p>
+          <div class="stats-grid" role="list">
+            <article class="stat-card" role="listitem">
+              <strong>65~</strong>
+              <span>успешных продаж за 3&nbsp;года, включая рождение новых проектов</span>
+            </article>
+            <article class="stat-card" role="listitem">
+              <strong>185+</strong>
+              <span>дорог, посланных нашим реагентом, даже до самых крутых точек</span>
+            </article>
+            <article class="stat-card" role="listitem">
+              <strong>139+</strong>
+              <span>клиентов, на малейших пылинках наших исследований</span>
+            </article>
+          </div>
+          <button class="cta-button" type="button">Получить консультацию</button>
+        </div>
+        <div class="hero-visual" aria-hidden="true">
+          <div class="molecule">
+            <span class="atom"></span>
+            <span class="atom"></span>
+            <span class="atom"></span>
+            <span class="atom"></span>
+            <span class="atom"></span>
+            <span class="atom"></span>
+            <span class="connector"></span>
+            <span class="connector"></span>
+            <span class="connector"></span>
+            <span class="connector"></span>
+            <span class="connector"></span>
+            <span class="connector"></span>
+          </div>
+        </div>
+      </section>
+
+      <section class="about">
+        <div class="about-card">
+          <div class="about-media">
+            <div class="about-media-main">
+              <img
+                src="https://images.unsplash.com/photo-1580894906472-2a6b0a0f981b?auto=format&fit=crop&w=1200&q=80"
+                alt="Высокотехнологичное производство"
+                loading="lazy"
+              />
+            </div>
+            <div class="about-gallery">
+              <figure class="about-thumb">
+                <img
+                  src="https://images.unsplash.com/photo-1600880292089-90a7e086ee0c?auto=format&fit=crop&w=400&q=80"
+                  alt="Фасовочная линия"
+                  loading="lazy"
+                />
+                <figcaption>Фасовка</figcaption>
+              </figure>
+              <figure class="about-thumb">
+                <img
+                  src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=400&q=80"
+                  alt="Офис флагман"
+                  loading="lazy"
+                />
+                <figcaption>Офис</figcaption>
+              </figure>
+              <figure class="about-thumb">
+                <img
+                  src="https://images.unsplash.com/photo-1517245386807-bb43f82c33c4?auto=format&fit=crop&w=400&q=80"
+                  alt="Команда специалистов"
+                  loading="lazy"
+                />
+                <figcaption>Команда</figcaption>
+              </figure>
+            </div>
+          </div>
+          <div class="about-content">
+            <header class="about-header">
+              <h2>О компании</h2>
+              <a class="about-link" href="pages/about.html">Узнать больше</a>
+            </header>
+            <p>
+              Но понимание сути ресурсосберегающих технологий требует анализа
+              вызовов текущих активов. Безусловно, высококачественный прототип
+              будущего проекта предполагает лучшие времена для начала войны в
+              Нарнии. Поэтому лучше быть с нами, чем с ними. ГОПоэтому лучше
+              сделать так, как надо, да, я так считаю
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/pages/about.html
+++ b/pages/about.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>О компании — flagman</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="../assets/css/style.css" />
+  </head>
+  <body>
+    <header>
+      <nav class="navbar">
+        <a class="brand" href="../index.html">flagman</a>
+        <div class="nav-links">
+          <a class="nav-link" href="../index.html">Главная</a>
+          <a class="nav-link" href="catalog.html">Каталог</a>
+          <a class="nav-link is-active" href="about.html">О нас</a>
+          <a class="nav-link" href="contacts.html">Контакты</a>
+        </div>
+        <div class="social-links">
+          <a class="social-circle" href="https://vk.com">VK</a>
+          <a class="social-circle" href="tel:+73472000000">☎</a>
+        </div>
+      </nav>
+    </header>
+    <main class="main-wrapper">
+      <section class="hero">
+        <div class="hero-card">
+          <h1>Мы — команда flagman</h1>
+          <p>
+            Наша миссия — делать химические продукты эстетичными и понятными. Мы соединяем научный подход с вниманием к деталям и
+            создаём решения, которые вдохновляют.
+          </p>
+          <div class="stats-grid">
+            <article class="stat-card">
+              <strong>12</strong>
+              <span>лабораторий-партнёров по всей России</span>
+            </article>
+            <article class="stat-card">
+              <strong>48</strong>
+              <span>специалистов команды, от инженеров до дизайнеров</span>
+            </article>
+            <article class="stat-card">
+              <strong>200%</strong>
+              <span>рост доверия клиентов за последние 2&nbsp;года</span>
+            </article>
+          </div>
+          <a class="cta-button" href="contacts.html">Познакомиться</a>
+        </div>
+        <div class="hero-visual" aria-hidden="true">
+          <div class="molecule">
+            <span class="atom"></span>
+            <span class="atom"></span>
+            <span class="atom"></span>
+            <span class="atom"></span>
+            <span class="atom"></span>
+            <span class="atom"></span>
+            <span class="connector"></span>
+            <span class="connector"></span>
+            <span class="connector"></span>
+            <span class="connector"></span>
+            <span class="connector"></span>
+            <span class="connector"></span>
+          </div>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/pages/about.html
+++ b/pages/about.html
@@ -6,66 +6,163 @@
     <title>О компании — flagman</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
     <link rel="stylesheet" href="../assets/css/style.css" />
   </head>
   <body>
-    <header>
-      <nav class="navbar">
-        <a class="brand" href="../index.html">flagman</a>
-        <div class="nav-links">
-          <a class="nav-link" href="../index.html">Главная</a>
-          <a class="nav-link" href="catalog.html">Каталог</a>
-          <a class="nav-link is-active" href="about.html">О нас</a>
-          <a class="nav-link" href="contacts.html">Контакты</a>
-        </div>
-        <div class="social-links">
-          <a class="social-circle" href="https://vk.com">VK</a>
-          <a class="social-circle" href="tel:+73472000000">☎</a>
-        </div>
-      </nav>
+    <header class="site-header">
+      <div class="container">
+        <nav class="navbar" aria-label="Основная навигация">
+          <a class="brand" href="../index.html">flagman</a>
+          <div class="navbar__menu">
+            <a class="menu-link" href="../index.html">Главная</a>
+            <a class="menu-link" href="catalog.html">Каталог</a>
+            <a class="menu-link is-current" href="about.html">О нас</a>
+            <a class="menu-link" href="contacts.html">Контакты</a>
+          </div>
+          <div class="navbar__actions">
+            <a class="circle-link" href="https://vk.com" aria-label="Мы во ВКонтакте">VK</a>
+            <a class="circle-link" href="tel:+73472000000" aria-label="Позвонить">☎</a>
+          </div>
+        </nav>
+      </div>
     </header>
-    <main class="main-wrapper">
-      <section class="hero">
-        <div class="hero-card">
-          <h1>Мы — команда flagman</h1>
-          <p>
-            Наша миссия — делать химические продукты эстетичными и понятными. Мы соединяем научный подход с вниманием к деталям и
-            создаём решения, которые вдохновляют.
-          </p>
-          <div class="stats-grid">
-            <article class="stat-card">
-              <strong>12</strong>
-              <span>лабораторий-партнёров по всей России</span>
+
+    <main class="site-main">
+      <section class="page-hero">
+        <div class="container page-hero__layout">
+          <div class="page-hero__card">
+            <p class="eyebrow">О компании</p>
+            <h1>Мы выстраиваем культуру химических инноваций</h1>
+            <p>
+              Flagman объединяет инженеров, химиков, дизайнеров и стратегов. Мы видим красоту в точности формул и считаем, что современные химические продукты должны быть понятными, безопасными и впечатляющими визуально.
+            </p>
+            <div class="badge-list" role="list">
+              <span class="badge" role="listitem">Основаны в 2015</span>
+              <span class="badge" role="listitem">R&amp;D центр — Уфа</span>
+              <span class="badge" role="listitem">Проекты в 6 странах</span>
+            </div>
+          </div>
+          <div class="page-hero__card">
+            <strong>Команда flagman</strong>
+            <p>
+              Наша структура устроена вокруг проектных ядер. Для каждого клиента мы собираем кросс-функциональную команду, которая ведёт продукт от гипотезы до масштабного производства.
+            </p>
+            <div class="values-grid">
+              <div class="values-card">
+                <strong>Аналитики</strong>
+                <p>Исследуют рынок, следят за нормативами и проверяют гипотезы на устойчивость.</p>
+              </div>
+              <div class="values-card">
+                <strong>Инженеры</strong>
+                <p>Проектируют рецептуры, контролируют пилотные партии и внедряют производство.</p>
+              </div>
+              <div class="values-card">
+                <strong>Дизайнеры</strong>
+                <p>Формируют визуальный язык продукта, интерфейсы для операторов и упаковку.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="container">
+          <div class="section-header">
+            <p class="eyebrow">Ценности</p>
+            <h2>Технологичность, открытость и ответственность</h2>
+            <p>
+              Мы выстраиваем долгосрочные отношения с партнёрами и инвестируем в устойчивые процессы. Уделяем внимание деталям, которые создают доверие: прозрачная коммуникация, аккуратная документация и дизайн, отражающий уровень продукта.
+            </p>
+          </div>
+          <div class="values-grid">
+            <article class="values-card">
+              <strong>Партнёрство</strong>
+              <p>Открыто делимся прогрессом, подстраиваемся под процессы клиентов и остаёмся на связи после внедрения.</p>
             </article>
-            <article class="stat-card">
-              <strong>48</strong>
-              <span>специалистов команды, от инженеров до дизайнеров</span>
+            <article class="values-card">
+              <strong>Инновации</strong>
+              <p>Проводим эксперименты в собственных лабораториях, тестируем материалы и внедряем лучшие практики отрасли.</p>
             </article>
-            <article class="stat-card">
-              <strong>200%</strong>
-              <span>рост доверия клиентов за последние 2&nbsp;года</span>
+            <article class="values-card">
+              <strong>Ответственность</strong>
+              <p>Следуем ESG-стандартам, внедряем безопасные методы утилизации и оптимизируем ресурсы.</p>
+            </article>
+            <article class="values-card">
+              <strong>Эстетика</strong>
+              <p>Понимаем важность визуальной коммуникации. Каждое решение сопровождается продуманным дизайном.</p>
             </article>
           </div>
-          <a class="cta-button" href="contacts.html">Познакомиться</a>
         </div>
-        <div class="hero-visual" aria-hidden="true">
-          <div class="molecule">
-            <span class="atom"></span>
-            <span class="atom"></span>
-            <span class="atom"></span>
-            <span class="atom"></span>
-            <span class="atom"></span>
-            <span class="atom"></span>
-            <span class="connector"></span>
-            <span class="connector"></span>
-            <span class="connector"></span>
-            <span class="connector"></span>
-            <span class="connector"></span>
-            <span class="connector"></span>
+      </section>
+
+      <section class="section">
+        <div class="container">
+          <div class="section-header">
+            <p class="eyebrow">Как мы работаем</p>
+            <h2>Этапы взаимодействия с заказчиком</h2>
+            <p>
+              Превращаем сложные задачи в прозрачный процесс: вы всегда знаете, на каком этапе находится проект и какие шаги нас ждут дальше.
+            </p>
+          </div>
+          <div class="timeline">
+            <article class="timeline-item">
+              <strong>01. Диагностика</strong>
+              <p>Собираем данные о текущих процессах, проводим аудит лабораторий и оцениваем технологический стек.</p>
+            </article>
+            <article class="timeline-item">
+              <strong>02. Проектирование</strong>
+              <p>Формируем гипотезы, подбираем реагенты, создаём прототипы и план пилотного запуска.</p>
+            </article>
+            <article class="timeline-item">
+              <strong>03. Внедрение</strong>
+              <p>Настраиваем поставки, обучаем команду заказчика и сопровождаем запуск до выхода на мощность.</p>
+            </article>
+            <article class="timeline-item">
+              <strong>04. Поддержка</strong>
+              <p>Обеспечиваем контроль качества, оптимизацию процессов и обновление дизайна продукта.</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section cta">
+        <div class="container">
+          <div class="cta__card">
+            <div>
+              <p class="eyebrow">Готовы к диалогу</p>
+              <h2>Найдем формат сотрудничества</h2>
+              <p>
+                Опишите ваш вызов, и мы подготовим стратегию: от консультации по отдельной линии до полного строительства химического направления.
+              </p>
+            </div>
+            <a class="button button--accent" href="contacts.html">Связаться с командой</a>
           </div>
         </div>
       </section>
     </main>
+
+    <footer class="site-footer">
+      <div class="container footer__grid">
+        <div class="footer__brand">
+          <a class="brand" href="../index.html">flagman</a>
+          <p>Инженерим химию будущего и превращаем сложные процессы в аккуратные продукты.</p>
+        </div>
+        <div class="footer__links">
+          <a href="../index.html">Главная</a>
+          <a href="catalog.html">Каталог</a>
+          <a href="about.html">О нас</a>
+          <a href="contacts.html">Контакты</a>
+        </div>
+        <div class="footer__contact">
+          <span>Уфа, ул. Индустриальная, 12</span>
+          <a href="tel:+73472000000">+7 (347) 200-00-00</a>
+          <a href="mailto:hello@flagman.ru">hello@flagman.ru</a>
+        </div>
+      </div>
+    </footer>
   </body>
 </html>

--- a/pages/catalog.html
+++ b/pages/catalog.html
@@ -6,65 +6,156 @@
     <title>Каталог — flagman</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
     <link rel="stylesheet" href="../assets/css/style.css" />
   </head>
   <body>
-    <header>
-      <nav class="navbar">
-        <a class="brand" href="../index.html">flagman</a>
-        <div class="nav-links">
-          <a class="nav-link" href="../index.html">Главная</a>
-          <a class="nav-link is-active" href="catalog.html">Каталог</a>
-          <a class="nav-link" href="about.html">О нас</a>
-          <a class="nav-link" href="contacts.html">Контакты</a>
-        </div>
-        <div class="social-links">
-          <a class="social-circle" href="https://vk.com">VK</a>
-          <a class="social-circle" href="tel:+73472000000">☎</a>
-        </div>
-      </nav>
+    <header class="site-header">
+      <div class="container">
+        <nav class="navbar" aria-label="Основная навигация">
+          <a class="brand" href="../index.html">flagman</a>
+          <div class="navbar__menu">
+            <a class="menu-link" href="../index.html">Главная</a>
+            <a class="menu-link is-current" href="catalog.html">Каталог</a>
+            <a class="menu-link" href="about.html">О нас</a>
+            <a class="menu-link" href="contacts.html">Контакты</a>
+          </div>
+          <div class="navbar__actions">
+            <a class="circle-link" href="https://vk.com" aria-label="Мы во ВКонтакте">VK</a>
+            <a class="circle-link" href="tel:+73472000000" aria-label="Позвонить">☎</a>
+          </div>
+        </nav>
+      </div>
     </header>
-    <main class="main-wrapper">
-      <section class="hero">
-        <div class="hero-card">
-          <h1>Каталог продукции</h1>
-          <p>
-            Мы готовим полный список решений для нефтехимии, машиностроения и фармацевтики. Скоро здесь появится интерактивный каталог.
-          </p>
-          <div class="stats-grid">
-            <article class="stat-card">
-              <strong>24</strong>
-              <span>актуальных сегмента рынка</span>
+
+    <main class="site-main">
+      <section class="page-hero">
+        <div class="container page-hero__layout">
+          <div class="page-hero__card">
+            <p class="eyebrow">Каталог</p>
+            <h1>Портфель химических решений</h1>
+            <p>
+              Мы подбираем сырьё и производим реагенты под конкретные задачи отрасли. Каталог постоянно дополняется благодаря совместным исследованиям с партнёрами и лабораториями.
+            </p>
+            <div class="badge-list" role="list">
+              <span class="badge" role="listitem">350+ позиций</span>
+              <span class="badge" role="listitem">24 сегмента рынка</span>
+              <span class="badge" role="listitem">Индивидуальные формулы</span>
+            </div>
+          </div>
+          <div class="page-hero__card">
+            <strong>Сферы применения</strong>
+            <p>Наша продукция закрывает потребности индустрий от нефтехимии до foodtech. Ниже — основные направления поставок.</p>
+            <div class="values-grid">
+              <div class="values-card">
+                <strong>Нефтехимия</strong>
+                <p>Катализаторы, ингибиторы коррозии, присадки к топливу.</p>
+              </div>
+              <div class="values-card">
+                <strong>Машиностроение</strong>
+                <p>Охлаждающие жидкости, смазки и составы для обработки металлов.</p>
+              </div>
+              <div class="values-card">
+                <strong>Фармацевтика</strong>
+                <p>Чистые растворители, лабораторные реактивы и расходники.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="container">
+          <div class="section-header">
+            <p class="eyebrow">Популярные категории</p>
+            <h2>Подборка решений для быстрого старта</h2>
+            <p>Готовые к внедрению линейки, которые чаще всего выбирают наши клиенты. Любую позицию можно адаптировать под ваши требования.</p>
+          </div>
+          <div class="catalog-grid">
+            <article class="catalog-card">
+              <strong>Реагенты для водоподготовки</strong>
+              <p>Флокулянты, коагулянты, корректоры pH и реагенты для мембранных систем.</p>
+              <ul>
+                <li>Промышленная очистка</li>
+                <li>Тепловые сети</li>
+                <li>Пищевые предприятия</li>
+              </ul>
             </article>
-            <article class="stat-card">
-              <strong>350+</strong>
-              <span>ассортимент химических реагентов</span>
+            <article class="catalog-card">
+              <strong>Композиты и смолы</strong>
+              <p>Эпоксидные, полиэфирные и полиуретановые системы для композитного производства.</p>
+              <ul>
+                <li>Натяжные конструкции</li>
+                <li>Авиастроение</li>
+                <li>Малые архитектурные формы</li>
+              </ul>
             </article>
-            <article class="stat-card">
-              <strong>∞</strong>
-              <span>вариантов индивидуальных решений</span>
+            <article class="catalog-card">
+              <strong>Чистящие составы</strong>
+              <p>Высокотехнологичные очистители и обезжириватели для промышленного оборудования.</p>
+              <ul>
+                <li>Линии розлива</li>
+                <li>Медицинская техника</li>
+                <li>Электроника</li>
+              </ul>
+            </article>
+            <article class="catalog-card">
+              <strong>Упаковочные решения</strong>
+              <p>Фирменные канистры, защитная тара и адаптивная маркировка для безопасных поставок.</p>
+              <ul>
+                <li>Пищевые концентраты</li>
+                <li>Косметическая продукция</li>
+                <li>Технические жидкости</li>
+              </ul>
             </article>
           </div>
-          <a class="cta-button" href="contacts.html">Запросить прайс</a>
+          <div class="catalog-highlight">
+            <strong>Не нашли нужную позицию?</strong>
+            <p>
+              Соберём кастомный комплект реагентов и упаковки. Поможем с сертификацией и адаптацией технологической документации под ваш регион.
+            </p>
+            <a class="button button--ghost" href="contacts.html">Оставить запрос</a>
+          </div>
         </div>
-        <div class="hero-visual" aria-hidden="true">
-          <div class="molecule">
-            <span class="atom"></span>
-            <span class="atom"></span>
-            <span class="atom"></span>
-            <span class="atom"></span>
-            <span class="atom"></span>
-            <span class="atom"></span>
-            <span class="connector"></span>
-            <span class="connector"></span>
-            <span class="connector"></span>
-            <span class="connector"></span>
-            <span class="connector"></span>
-            <span class="connector"></span>
+      </section>
+
+      <section class="section cta">
+        <div class="container">
+          <div class="cta__card">
+            <div>
+              <p class="eyebrow">Доступно по подписке</p>
+              <h2>Обновляем ассортимент ежемесячно</h2>
+              <p>
+                Подпишитесь на рассылку, чтобы получать обновления каталога, кейсы и предложения по оптимизации расходов.
+              </p>
+            </div>
+            <a class="button button--accent" href="contacts.html">Подписаться</a>
           </div>
         </div>
       </section>
     </main>
+
+    <footer class="site-footer">
+      <div class="container footer__grid">
+        <div class="footer__brand">
+          <a class="brand" href="../index.html">flagman</a>
+          <p>Инженерим химию будущего и превращаем сложные процессы в аккуратные продукты.</p>
+        </div>
+        <div class="footer__links">
+          <a href="../index.html">Главная</a>
+          <a href="catalog.html">Каталог</a>
+          <a href="about.html">О нас</a>
+          <a href="contacts.html">Контакты</a>
+        </div>
+        <div class="footer__contact">
+          <span>Уфа, ул. Индустриальная, 12</span>
+          <a href="tel:+73472000000">+7 (347) 200-00-00</a>
+          <a href="mailto:hello@flagman.ru">hello@flagman.ru</a>
+        </div>
+      </div>
+    </footer>
   </body>
 </html>

--- a/pages/catalog.html
+++ b/pages/catalog.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Каталог — flagman</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="../assets/css/style.css" />
+  </head>
+  <body>
+    <header>
+      <nav class="navbar">
+        <a class="brand" href="../index.html">flagman</a>
+        <div class="nav-links">
+          <a class="nav-link" href="../index.html">Главная</a>
+          <a class="nav-link is-active" href="catalog.html">Каталог</a>
+          <a class="nav-link" href="about.html">О нас</a>
+          <a class="nav-link" href="contacts.html">Контакты</a>
+        </div>
+        <div class="social-links">
+          <a class="social-circle" href="https://vk.com">VK</a>
+          <a class="social-circle" href="tel:+73472000000">☎</a>
+        </div>
+      </nav>
+    </header>
+    <main class="main-wrapper">
+      <section class="hero">
+        <div class="hero-card">
+          <h1>Каталог продукции</h1>
+          <p>
+            Мы готовим полный список решений для нефтехимии, машиностроения и фармацевтики. Скоро здесь появится интерактивный каталог.
+          </p>
+          <div class="stats-grid">
+            <article class="stat-card">
+              <strong>24</strong>
+              <span>актуальных сегмента рынка</span>
+            </article>
+            <article class="stat-card">
+              <strong>350+</strong>
+              <span>ассортимент химических реагентов</span>
+            </article>
+            <article class="stat-card">
+              <strong>∞</strong>
+              <span>вариантов индивидуальных решений</span>
+            </article>
+          </div>
+          <a class="cta-button" href="contacts.html">Запросить прайс</a>
+        </div>
+        <div class="hero-visual" aria-hidden="true">
+          <div class="molecule">
+            <span class="atom"></span>
+            <span class="atom"></span>
+            <span class="atom"></span>
+            <span class="atom"></span>
+            <span class="atom"></span>
+            <span class="atom"></span>
+            <span class="connector"></span>
+            <span class="connector"></span>
+            <span class="connector"></span>
+            <span class="connector"></span>
+            <span class="connector"></span>
+            <span class="connector"></span>
+          </div>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/pages/contacts.html
+++ b/pages/contacts.html
@@ -6,65 +6,115 @@
     <title>Контакты — flagman</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
     <link rel="stylesheet" href="../assets/css/style.css" />
   </head>
   <body>
-    <header>
-      <nav class="navbar">
-        <a class="brand" href="../index.html">flagman</a>
-        <div class="nav-links">
-          <a class="nav-link" href="../index.html">Главная</a>
-          <a class="nav-link" href="catalog.html">Каталог</a>
-          <a class="nav-link" href="about.html">О нас</a>
-          <a class="nav-link is-active" href="contacts.html">Контакты</a>
-        </div>
-        <div class="social-links">
-          <a class="social-circle" href="https://vk.com">VK</a>
-          <a class="social-circle" href="tel:+73472000000">☎</a>
-        </div>
-      </nav>
+    <header class="site-header">
+      <div class="container">
+        <nav class="navbar" aria-label="Основная навигация">
+          <a class="brand" href="../index.html">flagman</a>
+          <div class="navbar__menu">
+            <a class="menu-link" href="../index.html">Главная</a>
+            <a class="menu-link" href="catalog.html">Каталог</a>
+            <a class="menu-link" href="about.html">О нас</a>
+            <a class="menu-link is-current" href="contacts.html">Контакты</a>
+          </div>
+          <div class="navbar__actions">
+            <a class="circle-link" href="https://vk.com" aria-label="Мы во ВКонтакте">VK</a>
+            <a class="circle-link" href="tel:+73472000000" aria-label="Позвонить">☎</a>
+          </div>
+        </nav>
+      </div>
     </header>
-    <main class="main-wrapper">
-      <section class="hero">
-        <div class="hero-card">
-          <h1>Получите консультацию</h1>
-          <p>
-            Оставьте контакты, и мы свяжемся с вами для подбора химической продукции, расчёта поставок и логистики.
-          </p>
-          <form class="stats-grid" action="#" method="post">
-            <label class="stat-card">
-              <span>Ваше имя</span>
-              <input type="text" name="name" placeholder="Иван" required />
-            </label>
-            <label class="stat-card">
-              <span>Компания</span>
-              <input type="text" name="company" placeholder="ООО &ldquo;Прогресс&rdquo;" />
-            </label>
-            <label class="stat-card">
-              <span>Телефон</span>
-              <input type="tel" name="phone" placeholder="+7 (347) 200-00-00" required />
-            </label>
-            <button class="cta-button" type="submit">Отправить заявку</button>
-          </form>
+
+    <main class="site-main">
+      <section class="page-hero">
+        <div class="container contact-grid">
+          <div class="contact-card">
+            <p class="eyebrow">Контакты</p>
+            <h1>Давайте обсудим задачу</h1>
+            <p>
+              Мы ответим в течение рабочего дня и предложим несколько форматов сотрудничества. Укажите удобный способ связи и кратко опишите запрос.
+            </p>
+            <div class="contact-details">
+              <span>Уфа, ул. Индустриальная, 12</span>
+              <a href="tel:+73472000000">+7 (347) 200-00-00</a>
+              <a href="mailto:hello@flagman.ru">hello@flagman.ru</a>
+              <span>Работаем: пн—пт, 09:00–19:00</span>
+            </div>
+            <div class="badge-list" role="list">
+              <span class="badge" role="listitem">Есть NDA</span>
+              <span class="badge" role="listitem">Экспресс-консультация 30 мин</span>
+            </div>
+          </div>
+          <div class="contact-card">
+            <form class="form-grid" action="#" method="post">
+              <label class="form-field">
+                <span>Имя</span>
+                <input type="text" name="name" placeholder="Иван" required />
+              </label>
+              <label class="form-field">
+                <span>Компания</span>
+                <input type="text" name="company" placeholder="ООО &ldquo;Прогресс&rdquo;" />
+              </label>
+              <label class="form-field">
+                <span>Телефон</span>
+                <input type="tel" name="phone" placeholder="+7 (347) 200-00-00" required />
+              </label>
+              <label class="form-field">
+                <span>Email</span>
+                <input type="email" name="email" placeholder="you@company.ru" />
+              </label>
+              <label class="form-field">
+                <span>Запрос</span>
+                <textarea name="message" placeholder="Опишите проект или задачу" required></textarea>
+              </label>
+              <div class="form-actions">
+                <button class="button button--accent" type="submit">Отправить заявку</button>
+              </div>
+            </form>
+          </div>
         </div>
-        <div class="hero-visual" aria-hidden="true">
-          <div class="molecule">
-            <span class="atom"></span>
-            <span class="atom"></span>
-            <span class="atom"></span>
-            <span class="atom"></span>
-            <span class="atom"></span>
-            <span class="atom"></span>
-            <span class="connector"></span>
-            <span class="connector"></span>
-            <span class="connector"></span>
-            <span class="connector"></span>
-            <span class="connector"></span>
-            <span class="connector"></span>
+      </section>
+
+      <section class="section cta">
+        <div class="container">
+          <div class="cta__card">
+            <div>
+              <p class="eyebrow">Встречи онлайн и офлайн</p>
+              <h2>Назначим демо-показ материалов</h2>
+              <p>
+                Проведём презентацию на вашей площадке или в нашем шоуруме, покажем образцы и расскажем об условиях сотрудничества.
+              </p>
+            </div>
+            <a class="button button--accent" href="tel:+73472000000">Позвонить сейчас</a>
           </div>
         </div>
       </section>
     </main>
+
+    <footer class="site-footer">
+      <div class="container footer__grid">
+        <div class="footer__brand">
+          <a class="brand" href="../index.html">flagman</a>
+          <p>Инженерим химию будущего и превращаем сложные процессы в аккуратные продукты.</p>
+        </div>
+        <div class="footer__links">
+          <a href="../index.html">Главная</a>
+          <a href="catalog.html">Каталог</a>
+          <a href="about.html">О нас</a>
+          <a href="contacts.html">Контакты</a>
+        </div>
+        <div class="footer__contact">
+          <span>Уфа, ул. Индустриальная, 12</span>
+          <a href="tel:+73472000000">+7 (347) 200-00-00</a>
+          <a href="mailto:hello@flagman.ru">hello@flagman.ru</a>
+        </div>
+      </div>
+    </footer>
   </body>
 </html>

--- a/pages/contacts.html
+++ b/pages/contacts.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Контакты — flagman</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="../assets/css/style.css" />
+  </head>
+  <body>
+    <header>
+      <nav class="navbar">
+        <a class="brand" href="../index.html">flagman</a>
+        <div class="nav-links">
+          <a class="nav-link" href="../index.html">Главная</a>
+          <a class="nav-link" href="catalog.html">Каталог</a>
+          <a class="nav-link" href="about.html">О нас</a>
+          <a class="nav-link is-active" href="contacts.html">Контакты</a>
+        </div>
+        <div class="social-links">
+          <a class="social-circle" href="https://vk.com">VK</a>
+          <a class="social-circle" href="tel:+73472000000">☎</a>
+        </div>
+      </nav>
+    </header>
+    <main class="main-wrapper">
+      <section class="hero">
+        <div class="hero-card">
+          <h1>Получите консультацию</h1>
+          <p>
+            Оставьте контакты, и мы свяжемся с вами для подбора химической продукции, расчёта поставок и логистики.
+          </p>
+          <form class="stats-grid" action="#" method="post">
+            <label class="stat-card">
+              <span>Ваше имя</span>
+              <input type="text" name="name" placeholder="Иван" required />
+            </label>
+            <label class="stat-card">
+              <span>Компания</span>
+              <input type="text" name="company" placeholder="ООО &ldquo;Прогресс&rdquo;" />
+            </label>
+            <label class="stat-card">
+              <span>Телефон</span>
+              <input type="tel" name="phone" placeholder="+7 (347) 200-00-00" required />
+            </label>
+            <button class="cta-button" type="submit">Отправить заявку</button>
+          </form>
+        </div>
+        <div class="hero-visual" aria-hidden="true">
+          <div class="molecule">
+            <span class="atom"></span>
+            <span class="atom"></span>
+            <span class="atom"></span>
+            <span class="atom"></span>
+            <span class="atom"></span>
+            <span class="atom"></span>
+            <span class="connector"></span>
+            <span class="connector"></span>
+            <span class="connector"></span>
+            <span class="connector"></span>
+            <span class="connector"></span>
+            <span class="connector"></span>
+          </div>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add the about company block to the landing page with CTA and description
- include media gallery with large production shot and supporting thumbnails
- extend shared stylesheet with about section layout and responsive rules

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d5255e83ec833395a254f4bbd9e256